### PR TITLE
chore(ci): init ci workflows

### DIFF
--- a/.github/workflows/github_pkgs.yml
+++ b/.github/workflows/github_pkgs.yml
@@ -1,0 +1,21 @@
+name: Release to Github Packages
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish-gpr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          registry-url: https://npm.pkg.github.com/
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,15 @@
+name: Validate tests
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Dependencies
+        run: yarn
+      - name: Build app
+        run: yarn test


### PR DESCRIPTION
This PR **implements** basic CI to deploy this to Github Packages, because NPM is soooooooooo 2010.